### PR TITLE
アプリ公開のための環境設定

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,8 @@ gem "rails", "~> 7.0.8"
 gem "sprockets-rails"
 
 # Use sqlite3 as the database for Active Record
-gem "sqlite3", "~> 1.4"
+gem 'sqlite3', group: :development
+gem 'pg', group: :production
 
 # Use the Puma web server [https://github.com/puma/puma]
 gem "puma", "~> 5.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -137,6 +137,7 @@ GEM
       racc (~> 1.4)
     nokogiri (1.16.2-x86_64-linux)
       racc (~> 1.4)
+    pg (1.5.5)
     pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -238,12 +239,13 @@ DEPENDENCIES
   debug
   importmap-rails
   jbuilder
+  pg
   pry-rails
   puma (~> 5.0)
   rails (~> 7.0.8)
   selenium-webdriver
   sprockets-rails
-  sqlite3 (~> 1.4)
+  sqlite3
   stimulus-rails
   turbo-rails
   tzinfo-data

--- a/config/database.yml
+++ b/config/database.yml
@@ -22,4 +22,6 @@ test:
 
 production:
   <<: *default
-  database: db/production.sqlite3
+  adapter: postgresql
+  encoding: unicode
+  pool: 5


### PR DESCRIPTION
概要
ソースコード内において、本番環境での環境設定をしておらず、(Herokuによる)アプリ公開ができなかったため、本番環境にも対応できるように設定を書き換え。

実装内容
・herokuでのアプリ公開をするためのGemのインストール
・PostgreSQLを使うためのconfig/database.ymlの中身の書き換え
・heroku run rails db:migrateを実行して、開発環境で設定したデータベースを、本番環境にも反映