### PR TITLE
投稿検索機能の拡張

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -713,6 +713,11 @@ h6 {
   font-weight: bold;
 }
 
+#spots .selected-condition{
+  pointer-events: none;
+  color: #000;
+}
+
 #spots .post-details-top {
   height: 50px;
   padding: 0 5px;

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -713,9 +713,19 @@ h6 {
   font-weight: bold;
 }
 
+#spots .condition-btn-area {
+  width: 220px;
+}
+
 #spots .selected-condition{
   pointer-events: none;
   color: #000;
+}
+
+#spots .separator {
+  width: 1.5px;
+  height: 18px;
+  background-color: #000;
 }
 
 #spots .post-details-top {

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -16,7 +16,7 @@ class PostsController < ApplicationController
   end
 
   def create
-    @post = Post.new(params.require(:post).permit(:title, :spot_name, :address, :content, :spot_image, :flow_video))
+    @post = Post.new(params.require(:post).permit(:title, :address, :content, :spot_image, :flow_video))
     @post.user_id = @current_user.id
     @post.user_name = @current_user.name
     if @post.save
@@ -38,7 +38,7 @@ class PostsController < ApplicationController
 
   def update
     @post = Post.find(params[:id])
-    if @post.update(params.require(:post).permit(:title, :spot_name, :address, :content, :spot_image, :flow_video))
+    if @post.update(params.require(:post).permit(:title, :address, :content, :spot_image, :flow_video))
       flash[:notice] = "「#{@post.title}」の情報を更新しました"
       redirect_to :posts
     else

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,6 +1,11 @@
 class PostsController < ApplicationController
   def index
-    @posts = Post.all
+    @posts = Post.latest
+    if params[:old]
+      @posts = Post.old
+    else
+      @posts = Post.latest
+    end
     @posts_count = @posts.count
   end
   

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -3,6 +3,8 @@ class PostsController < ApplicationController
     @posts = Post.latest
     if params[:old]
       @posts = Post.old
+    elsif params[:most_favorited]
+      @posts = Post.most_favorited
     else
       @posts = Post.latest
     end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -25,7 +25,7 @@ class Post < ApplicationRecord
 
   def self.search(search)
     if search != ""
-      Post.where(['title LIKE(?) OR spot_name LIKE(?) OR address LIKE(?) OR user_name LIKE(?)', "%#{search}%", "%#{search}%", "%#{search}%", "%#{search}%"])
+      Post.where(['title LIKE(?) OR address LIKE(?) OR user_name LIKE(?)', "%#{search}%", "%#{search}%", "%#{search}%"])
     else
       Post.all
     end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -12,6 +12,7 @@ class Post < ApplicationRecord
   after_validation :geocode
   belongs_to :user
   has_many :likes, dependent: :destroy
+  has_many :liked_users, through: :likes, source: :user
 
   def user
     return User.find_by(id: self.user_id)

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,6 +1,7 @@
 class Post < ApplicationRecord
   scope :latest, -> { order(created_at: :desc) }
   scope :old, -> { order(created_at: :asc) }
+  scope :most_favorited, -> { includes(:liked_users).sort_by { |x| x.liked_users.includes(:likes).size }.reverse }
   validates :title, {presence: true, length: {maximum: 30}}
   validates :content, {presence: true, length: {maximum: 500}}
   validates :address, presence: true

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,4 +1,5 @@
 class Post < ApplicationRecord
+  scope :latest, -> { order(created_at: :desc) }
   validates :title, {presence: true, length: {maximum: 30}}
   validates :content, {presence: true, length: {maximum: 500}}
   validates :address, presence: true

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,5 +1,6 @@
 class Post < ApplicationRecord
   scope :latest, -> { order(created_at: :desc) }
+  scope :old, -> { order(created_at: :asc) }
   validates :title, {presence: true, length: {maximum: 30}}
   validates :content, {presence: true, length: {maximum: 500}}
   validates :address, presence: true

--- a/app/views/home/top.html.erb
+++ b/app/views/home/top.html.erb
@@ -17,7 +17,7 @@
         <%= form_with(url: search_posts_path, local: true, method: :get ) do |f| %>
           <div class="row">
             <div class="col-lg-6 col-md-10 d-flex">
-              <%= f.text_field :keyword, class:"form-control border border-dark-subtle", placeholder:"投稿者、スポット名、タイトル、住所" %>
+              <%= f.text_field :keyword, class:"form-control border border-dark-subtle", placeholder:"投稿者、タイトル、住所" %>
               <%= f.button "検索", :type => "submit", class:"ms-2" %>
             </div>
           </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -42,7 +42,7 @@
               </li>
               <li><%= link_to "アプリについて", about_path %></li>
               <li><%= link_to "ユーザー", users_path %></li>
-              <li><%= link_to "スポット", posts_path %></li>
+              <li><%= link_to "スポット", posts_path(latest: "true") %></li>
             </ul>
             <i class="bi bi-list mobile-nav-toggle"></i>
           </nav>
@@ -96,7 +96,7 @@
                 <ul>
                   <li><i class="bi bi-chevron-right"></i><%= link_to "アプリについて", about_path %></li>
                   <li><i class="bi bi-chevron-right"></i><%= link_to "ユーザー一覧", users_path %></li>
-                  <li><i class="bi bi-chevron-right"></i><%= link_to "スポット一覧", posts_path %></li>
+                  <li><i class="bi bi-chevron-right"></i><%= link_to "スポット一覧", posts_path(latest: "true") %></li>
                   <li><i class="bi bi-chevron-right"></i><%= link_to "新規スポット投稿", new_post_path%></li>
                 </ul>
               </div>

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -7,21 +7,29 @@
     <div class="form form-content-area">
       <%= form_with model: @post do |f| %> 
         <div class="row">
-          <div class="form-group col-md-6">
-            <%= f.label :title, "投稿タイトル", class:"mb-3" %>
+          <div class="form-group mt-3 col-md-6">
+            <%= f.label :title, "投稿タイトル(30文字まで)", class:"mb-3" %>
             <%= f.text_field :title, class:"form-control", placeholder:"投稿タイトルを入力" %>
+            <p class="mt-1 nessessory-column">※ 入力必須項目です</p>
           </div>
-          <div class="form-group col-md-6">
+          <div class="form-group mt-3 col-md-6">
+            <%= f.label :address, "住所", class:"mb-3" %>
+            <%= f.text_field :address, placeholder: "住所を入力", class: "form-control" %>
+            <p class="mt-1 nessessory-column">※ 入力必須項目です</p>
+          </div>
+        </div>
+        <div class="row">
+          <div class="form-group mt-3 col-md-6">
             <%= f.label :spot_image, "スポット画像", class:"mb-3" %>
             <%= f.file_field :spot_image, id:"item-image", class:"form-control" %>
           </div>
+          <div class="form-group mt-3 col-md-6">
+            <%= f.label :flow_video, "フロー動画", class:"mb-3" %>
+            <%= f.file_field :flow_video, class:"form-control" %>
+          </div>
         </div>
         <div class="form-group mt-3">
-          <%= f.label :flow_video, "フロー動画", class:"mb-3" %>
-          <%= f.file_field :flow_video, class:"form-control" %>
-        </div>
-        <div class="form-group mt-3">
-          <%= f.label :content ,"投稿内容" ,class:"mb-3" %>
+          <%= f.label :content ,"投稿内容(500文字まで)" ,class:"mb-3" %>
           <%= f.text_area :content, class:"form-control", rows:"4", placeholder:"投稿内容を入力" %>
         </div>
         <div class="text-center mt-4">

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -17,6 +17,8 @@
       </div>
     </section>
     <h3>スポット件数: <%= @posts_count %>件</h3>
+    <%= link_to '新着順', posts_path(latest: "true") %>
+    <%= link_to '古い順', posts_path(old: "true") %>
     <div class="row">
       <% @posts.each do |post| %>
         <div class="col-lg-4 col-md-6">

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -17,7 +17,7 @@
       </div>
     </section>
     <h3>スポット件数: <%= @posts_count %>件</h3>
-    <%= link_to '新着順', posts_path(latest: "true") %>
+    <%= link_to '新着順', posts_path(latest: "true"), class:"#{ "selected-condition" if params[:latest] }" %>
     <%= link_to '古い順', posts_path(old: "true") %>
     <%= link_to 'いいね順', posts_path(most_favorited: "true") %>
     <div class="row">

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -19,6 +19,7 @@
     <h3>スポット件数: <%= @posts_count %>件</h3>
     <%= link_to '新着順', posts_path(latest: "true") %>
     <%= link_to '古い順', posts_path(old: "true") %>
+    <%= link_to 'いいね順', posts_path(most_favorited: "true") %>
     <div class="row">
       <% @posts.each do |post| %>
         <div class="col-lg-4 col-md-6">

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -68,11 +68,7 @@
               <% end %>
               <div class="post-details-bottom">
                 <h3><%= post.title %></h3>
-                <% if post.spot_name.present? %>
-                  <p><%= post.spot_name %></p>
-                <% else %>
-                  <p><%= post.address %></p>
-                <% end %>
+                <p><%= post.address %></p>
               </div>
             <% end %>
           </div>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -9,7 +9,7 @@
         <%= form_with(url: search_posts_path, local: true, method: :get ) do |f| %>
           <div class="row justify-content-center">
             <div class="col-lg-6 col-md-10 d-flex">
-              <%= f.text_field :keyword, class:"form-control border border-dark-subtle", placeholder:"投稿者、スポット名、タイトル、住所" %>
+              <%= f.text_field :keyword, class:"form-control border border-dark-subtle", placeholder:"投稿者、タイトル、住所" %>
               <%= f.button "検索", :type => "submit", class:"ms-2" %>
             </div>
           </div>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -17,9 +17,13 @@
       </div>
     </section>
     <h3>スポット件数: <%= @posts_count %>件</h3>
-    <%= link_to '新着順', posts_path(latest: "true"), class:"#{ "selected-condition" if params[:latest] }" %>
-    <%= link_to '古い順', posts_path(old: "true"), class:"#{ "selected-condition" if params[:old] }" %>
-    <%= link_to 'いいね順', posts_path(most_favorited: "true"), class:"#{ "selected-condition" if params[:most_favorited] }" %>
+    <div class="d-flex justify-content-between align-items-center condition-btn-area">
+      <%= link_to '新着順', posts_path(latest: "true"), class:"#{ "selected-condition" if params[:latest] }" %>
+      <span class="separator"></span>
+      <%= link_to '古い順', posts_path(old: "true"), class:"#{ "selected-condition" if params[:old] }" %>
+      <span class="separator"></span>
+      <%= link_to 'いいね順', posts_path(most_favorited: "true"), class:"#{ "selected-condition" if params[:most_favorited] }" %>
+    </div>
     <div class="row">
       <% @posts.each do |post| %>
         <div class="col-lg-4 col-md-6">

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -18,7 +18,7 @@
     </section>
     <h3>スポット件数: <%= @posts_count %>件</h3>
     <%= link_to '新着順', posts_path(latest: "true"), class:"#{ "selected-condition" if params[:latest] }" %>
-    <%= link_to '古い順', posts_path(old: "true") %>
+    <%= link_to '古い順', posts_path(old: "true"), class:"#{ "selected-condition" if params[:old] }" %>
     <%= link_to 'いいね順', posts_path(most_favorited: "true") %>
     <div class="row">
       <% @posts.each do |post| %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -19,7 +19,7 @@
     <h3>スポット件数: <%= @posts_count %>件</h3>
     <%= link_to '新着順', posts_path(latest: "true"), class:"#{ "selected-condition" if params[:latest] }" %>
     <%= link_to '古い順', posts_path(old: "true"), class:"#{ "selected-condition" if params[:old] }" %>
-    <%= link_to 'いいね順', posts_path(most_favorited: "true") %>
+    <%= link_to 'いいね順', posts_path(most_favorited: "true"), class:"#{ "selected-condition" if params[:most_favorited] }" %>
     <div class="row">
       <% @posts.each do |post| %>
         <div class="col-lg-4 col-md-6">

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -7,22 +7,22 @@
     <div class="form form-content-area">
       <%= form_with model: @post, url: posts_path do |f| %> 
         <div class="row">
-          <div class="form-group col-md-6">
+          <div class="form-group mt-3 col-md-6">
             <%= f.label :title, "投稿タイトル(30文字まで)", class:"mb-3" %>
             <%= f.text_field :title, class:"form-control", placeholder:"投稿タイトルを入力" %>
             <p class="mt-1 nessessory-column">※ 入力必須項目です</p>
           </div>
-          <div class="form-group col-md-6">
+          <div class="form-group mt-3 col-md-6">
+            <%= f.label :address, "住所", class:"mb-3" %>
+            <%= f.text_field :address, placeholder: "住所を入力", class: "form-control" %>
+            <p class="mt-1 nessessory-column">※ 入力必須項目です</p>
+          </div>
+        </div>
+        <div class="row">
+          <div class="form-group mt-3 col-md-6">
             <%= f.label :spot_image, "スポット画像", class:"mb-3" %>
             <%= f.file_field :spot_image, id:"item-image", class:"form-control" %>
           </div>
-        </div>
-        <div class="form-group mt-3">
-          <%= f.label :address, "住所", class:"mb-3" %>
-          <%= f.text_field :address, placeholder: "住所を入力", class: "form-control" %>
-          <p class="mt-1 nessessory-column">※ 入力必須項目です</p>
-        </div>
-        <div class="row">
           <div class="form-group mt-3 col-md-6">
             <%= f.label :flow_video, "フロー動画", class:"mb-3" %>
             <%= f.file_field :flow_video, class:"form-control" %>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -24,10 +24,6 @@
         </div>
         <div class="row">
           <div class="form-group mt-3 col-md-6">
-            <%= f.label :spot_name, "スポット名", class:"mb-3" %>
-            <%= f.text_field :spot_name, placeholder: "スポット名を入力", class: "form-control" %>
-          </div>
-          <div class="form-group mt-3 col-md-6">
             <%= f.label :flow_video, "フロー動画", class:"mb-3" %>
             <%= f.file_field :flow_video, class:"form-control" %>
           </div>

--- a/db/migrate/20240322021554_remove_spot_name_from_posts.rb
+++ b/db/migrate/20240322021554_remove_spot_name_from_posts.rb
@@ -1,0 +1,5 @@
+class RemoveSpotNameFromPosts < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :posts, :spot_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_03_06_220749) do
+ActiveRecord::Schema[7.0].define(version: 2024_03_22_021554) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -48,7 +48,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_06_220749) do
 
   create_table "posts", force: :cascade do |t|
     t.string "title"
-    t.string "spot_name"
     t.text "content"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -57,6 +56,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_06_220749) do
     t.float "latitude"
     t.float "longitude"
     t.string "user_name"
+    t.string "price"
   end
 
   create_table "relationships", force: :cascade do |t|


### PR DESCRIPTION
概要
投稿一覧・投稿検索結果ページにて、投稿が表示される順番を切り替えられるようにするための機能を実装

実装内容
・postもでるへの投稿を新着順・古い順・人気順に並べ替えるためのスコープの設定
・postコントローラーへ設定したスコープの適用
・投稿一覧・投稿検索結果ページへの表示順を切り替えるボタンの実装
・postモデルの一部カラムの除外
・一部カラム除外に伴う新規投稿作成・編集フォームの変更

並べ替えを切り替えるためのスコープについて
scope :latest, -> { includes([spot_image_attachment: :blob]).order(created_at: :desc) }
scope :old, -> { includes([spot_image_attachment: :blob]).order(created_at: :asc) }
scope :most_favorited, -> { includes([spot_image_attachment: :blob]).sort_by { |x| x.liked_users.includes(:likes).size }.reverse }

latest = 投稿作成日時が新しい順
order(created_at: :desc) = 投稿作成日時を降順で取得(古→新)

old = 投稿作成日時が古い順
order(created_at: :asc) = 投稿作成日時を昇順で取得(新→古)

most_favorited = いいねの数が多い順
includes(:liked_users) = 特定の投稿に対していいねしたユーザーに絞り込み
sort_by { |x| x.liked_users.includes(:likes).size }.reverse } = いいねしたユーザー数によって並べ替え(reverseで降順化)