### PR TITLE
n＋1の検出と回避

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,6 +64,7 @@ end
 group :development do
   # Use console on exceptions pages [https://github.com/rails/web-console]
   gem "web-console"
+  gem 'bullet'
 
   # Add speed badges [https://github.com/MiniProfiler/rack-mini-profiler]
   # gem "rack-mini-profiler"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,6 +91,9 @@ GEM
     bootsnap (1.18.3)
       msgpack (~> 1.2)
     builder (3.2.4)
+    bullet (7.1.6)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.11)
     capybara (3.40.0)
       addressable
       matrix
@@ -253,6 +256,7 @@ GEM
       railties (>= 6.0.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    uniform_notifier (1.16.0)
     web-console (4.2.1)
       actionview (>= 6.0.0)
       activemodel (>= 6.0.0)
@@ -275,6 +279,7 @@ DEPENDENCIES
   activestorage-validator
   aws-sdk-s3
   bootsnap
+  bullet
   capybara
   debug
   dotenv-rails

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,7 +4,7 @@ class UsersController < ApplicationController
   before_action :ensure_correct_user, {only: [:edit, :update]}
 
   def index
-    @users = User.all
+    @users = User.includes([:image_attachment])
     @users_count = @users.count
   end
 

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,6 +1,6 @@
 class Post < ApplicationRecord
   scope :latest, -> { includes([spot_image_attachment: :blob]).order(created_at: :desc) }
-  scope :old, -> { order(created_at: :asc) }
+  scope :old, -> { includes([spot_image_attachment: blob]).order(created_at: :asc) }
   scope :most_favorited, -> { includes([:spot_image_attachment]).sort_by { |x| x.liked_users.includes(:likes).size }.reverse }
   validates :title, { presence: true, length: { maximum: 30 } }
   validates :content, length: { maximum: 500 }

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,7 +1,7 @@
 class Post < ApplicationRecord
   scope :latest, -> { includes([spot_image_attachment: :blob]).order(created_at: :desc) }
   scope :old, -> { includes([spot_image_attachment: :blob]).order(created_at: :asc) }
-  scope :most_favorited, -> { includes([:spot_image_attachment]).sort_by { |x| x.liked_users.includes(:likes).size }.reverse }
+  scope :most_favorited, -> { includes([spot_image_attachment: :blob]).sort_by { |x| x.liked_users.includes(:likes).size }.reverse }
   validates :title, { presence: true, length: { maximum: 30 } }
   validates :content, length: { maximum: 500 }
   validates :address, presence: true

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,7 +1,7 @@
 class Post < ApplicationRecord
-  scope :latest, -> { order(created_at: :desc) }
+  scope :latest, -> { includes([spot_image_attachment: :blob]).order(created_at: :desc) }
   scope :old, -> { order(created_at: :asc) }
-  scope :most_favorited, -> { includes(:liked_users).sort_by { |x| x.liked_users.includes(:likes).size }.reverse }
+  scope :most_favorited, -> { includes([:spot_image_attachment]).sort_by { |x| x.liked_users.includes(:likes).size }.reverse }
   validates :title, { presence: true, length: { maximum: 30 } }
   validates :content, length: { maximum: 500 }
   validates :address, presence: true

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,6 +1,6 @@
 class Post < ApplicationRecord
   scope :latest, -> { includes([spot_image_attachment: :blob]).order(created_at: :desc) }
-  scope :old, -> { includes([spot_image_attachment: blob]).order(created_at: :asc) }
+  scope :old, -> { includes([spot_image_attachment: :blob]).order(created_at: :asc) }
   scope :most_favorited, -> { includes([:spot_image_attachment]).sort_by { |x| x.liked_users.includes(:likes).size }.reverse }
   validates :title, { presence: true, length: { maximum: 30 } }
   validates :content, length: { maximum: 500 }

--- a/app/views/users/_posts.html.erb
+++ b/app/views/users/_posts.html.erb
@@ -1,6 +1,6 @@
 <div role="tabpanel" class="col-lg-9 tab-pane fade show active" id="table-1">
   <p>投稿数: <%= user_posts_count %>件</p>
-  <% user.posts.each do |post| %>
+  <% user.posts.includes([spot_image_attachment: :blob]).each do |post| %>
     <div class="table-item">
       <div class="d-flex mb-2 align-items-center">
         <%= link_to user_path(post.user) do %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,6 +1,15 @@
 require "active_support/core_ext/integer/time"
 
 Rails.application.configure do
+  config.after_initialize do
+    Bullet.enable        = true
+    Bullet.alert         = true
+    Bullet.bullet_logger = true
+    Bullet.console       = true
+    Bullet.rails_logger  = true
+    Bullet.add_footer    = true
+  end
+
   # Settings specified here will take precedence over those in config/application.rb.
 
   # In the development environment your application's code is reloaded any time


### PR DESCRIPTION
概要
作成したコントローラーファイルやモデルファイル内で作成・定義した変数やスコープによって発生したn＋1の排除

実装内容
・n＋1を検出するためのgem「bullet」のインストール
・n＋1を検出した時に、ページ上にログとして表示させるための設定
・対象の変数やスコープの書き換え

書き換えた箇所
①投稿一覧で表示させる投稿を取得する際に条件分けするための3種類のスコープ(postモデル内)
新着順 = scope :latest, -> { includes([spot_image_attachment: :blob]).order(created_at: :desc) }
古い順 = scope :old, -> { includes([spot_image_attachment: :blob]).order(created_at: :asc) }
人気順 = scope :most_favorited, -> { includes([spot_image_attachment: :blob]).sort_by { |x| x.liked_users.includes(:likes).size }.reverse }

②ユーザー一覧で表示させる全ユーザーを取得する変数(userコントローラーのindexアクション)
@users = User.includes([:image_attachment])

③ユーザー詳細ページでのユーザーが作成した投稿を取得する変数(htmlのeachメソッド内)
<% user.posts.includes([spot_image_attachment: :blob]).each do |post| %>