### PR TITLE
n＋1の検出と回避の続き・フォロー、フォロワー機能での誤作動の修正

### DIFF
--- a/app/controllers/relationships_controller.rb
+++ b/app/controllers/relationships_controller.rb
@@ -18,6 +18,6 @@ class RelationshipsController < ApplicationController
 
   def followers
     user = User.find(params[:user_id])
-    @users = user.followers
+    @users = user.followers.includes([image_attachment: :blob])
   end
 end

--- a/app/controllers/relationships_controller.rb
+++ b/app/controllers/relationships_controller.rb
@@ -13,7 +13,7 @@ class RelationshipsController < ApplicationController
 
   def followings
     user = User.find(params[:user_id])
-    @users = user.followings
+    @users = user.followings.includes([image_attachment: :blob])
   end
 
   def followers

--- a/app/views/relationships/followers.html.erb
+++ b/app/views/relationships/followers.html.erb
@@ -6,9 +6,9 @@
       <p>フォロワー一覧</p>
     </div>
     <div class="d-flex justify-content-between align-items-center condition-btn-area mb-4">
-      <%= link_to "フォロワー一覧", user_followers_path(@current_user), class:"selected-condition" %>
+      <%= link_to "フォロワー一覧", user_followers_path, class:"selected-condition" %>
       <span class="separator"></span>
-      <%= link_to "フォロー一覧", user_followings_path(@current_user) %>
+      <%= link_to "フォロー一覧", user_followings_path %>
     </div>
     <%= render 'shared/relationships/table', users: @users, current_user: @current_user %>
   <div>

--- a/app/views/relationships/followings.html.erb
+++ b/app/views/relationships/followings.html.erb
@@ -6,9 +6,9 @@
       <p>フォロー一覧</p>
     </div>
     <div class="d-flex justify-content-between align-items-center condition-btn-area mb-4">
-      <%= link_to "フォロワー一覧", user_followers_path(@current_user) %>
+      <%= link_to "フォロワー一覧", user_followers_path %>
       <span class="separator"></span>
-      <%= link_to "フォロー一覧", user_followings_path(@current_user), class:"selected-condition" %>
+      <%= link_to "フォロー一覧", user_followings_path, class:"selected-condition" %>
     </div>
     <%= render 'shared/relationships/table', users: @users, current_user: @current_user %>
   <div>

--- a/app/views/shared/relationships/_table.html.erb
+++ b/app/views/shared/relationships/_table.html.erb
@@ -19,7 +19,9 @@
               </div>
             </div>
             <div class="d-flex flex-column contents-area text-center">
-              <% if current_user.following?(user) %>
+              <% if current_user && user.id == current_user.id %>
+                <%= link_to "情報を編集する", edit_user_path(current_user), class:"align-self-center btn-1" %>
+              <% elsif current_user && current_user.following?(user) %>
                 <%= link_to "フォロー済み", user_relationships_path(user.id), data: { "turbo-method": :delete }, class:"btn-1" %>
               <% else %>
                 <%= link_to "フォローする", user_relationships_path(user.id), data: { "turbo-method": :post }, class:"btn-2" %>

--- a/app/views/shared/relationships/_table.html.erb
+++ b/app/views/shared/relationships/_table.html.erb
@@ -2,34 +2,32 @@
   <div role="tabpanel" class="col-lg-9 tab-pane fade show active">
     <% if users.exists? %>
       <% users.each do |user| %>
-        <% if user.id != current_user.id %>
-          <div class="table-item">
-            <div class="image-wrapper">
-              <% if user.image.attached? %>
-                <%= image_tag(rails_blob_path(user.image)) %>
-              <% else %>
-                <%= image_tag("default_user.png") %>
-              <% end %>
+        <div class="table-item">
+          <div class="image-wrapper">
+            <% if user.image.attached? %>
+              <%= image_tag(rails_blob_path(user.image)) %>
+            <% else %>
+              <%= image_tag("default_user.png") %>
+            <% end %>
+          </div>
+          <div class="d-flex justify-content-between align-items-center">
+            <div class="contents-area">
+              <h4><%= user.name %></h4>
+              <div class="d-flex">
+                <p class="mb-1 me-2">フォロー数: <%= user.followings.count %>人</p>
+                <p class="mb-1">フォロワー数: <%= user.followers.count %>人</p>
+              </div>
             </div>
-            <div class="d-flex justify-content-between align-items-center">
-              <div class="contents-area">
-                <h4><%= user.name %></h4>
-                <div class="d-flex">
-                  <p class="mb-1 me-2">フォロー数: <%= user.followings.count %>人</p>
-                  <p class="mb-1">フォロワー数: <%= user.followers.count %>人</p>
-                </div>
-              </div>
-              <div class="d-flex flex-column contents-area text-center">
-                <% if current_user.following?(user) %>
-                  <%= link_to "フォロー済み", user_relationships_path(user.id), data: { "turbo-method": :delete }, class:"btn-1" %>
-                <% else %>
-                  <%= link_to "フォローする", user_relationships_path(user.id), data: { "turbo-method": :post }, class:"btn-2" %>
-                <% end %>
-                <%= link_to "プロフィールへ", user_path(user), class:"btn-1 mt-1" %>
-              </div>
+            <div class="d-flex flex-column contents-area text-center">
+              <% if current_user.following?(user) %>
+                <%= link_to "フォロー済み", user_relationships_path(user.id), data: { "turbo-method": :delete }, class:"btn-1" %>
+              <% else %>
+                <%= link_to "フォローする", user_relationships_path(user.id), data: { "turbo-method": :post }, class:"btn-2" %>
+              <% end %>
+              <%= link_to "プロフィールへ", user_path(user), class:"btn-1 mt-1" %>
             </div>
           </div>
-        <% end %>
+        </div>
       <% end %>
     <% else %>
       <p>ユーザーはいません</p>

--- a/app/views/shared/users/_table.html.erb
+++ b/app/views/shared/users/_table.html.erb
@@ -19,7 +19,9 @@
             </div>
           </div>
           <div class="d-flex flex-column contents-area text-center">
-            <% if current_user && current_user.following?(user) %>
+            <% if current_user && user.id == current_user.id %>
+              <%= link_to "情報を編集する", edit_user_path(current_user), class:"align-self-center btn-1" %>
+            <% elsif current_user && current_user.following?(user) %>
               <%= link_to "フォロー済み", user_relationships_path(user.id), data: { "turbo-method": :delete }, class:"btn-1" %>
             <% else %>
               <%= link_to "フォローする", user_relationships_path(user.id), data: { "turbo-method": :post }, class:"btn-2" %>


### PR DESCRIPTION
概要
・n＋1の検出と回避の続き(前のurl: https://github.com/Magyuu52/flow_spot/pull/15)
・フォローとフォロワー機能における間違った記載による誤作動の修正

実装内容
・フォロー、フォロワー一覧ページで使用する表示させる全ユーザーを取得する変数の書き換え
・フォロー、フォロワー一覧ページで自身のユーザー情報が表示されなくなる条件の削除(フォロー・フォロワー数
　が、実際に表示されているユーザーの人数と一致しなくなるため)
・自身をフォローできないようにするために、フォロー・フォロー解除ボタンを、現在ログインしているユーザーのid
　と表示されているユーザーのidが一致する場合に、プロフィール編集ページが表示されるように条件を追加書き換え
・フォロー、フォロワー一覧ページの表示切り替えの誤作動(正しくフォロー・フォロワーが表示されない)の修正

書き換えた箇所
フォロー・フォロワー一覧ページで表示させる全ユーザーを取得する変数(relationshpコントローラーのfollowings・followersアクション)
・フォロー: @users = user.followings.includes([image_attachment: :blob])
・フォロワー: @users = user.followers.includes([image_attachment: :blob])